### PR TITLE
feat: adiciona ecossistema Dota (/dota e /dota/player/:steamId)

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -9,6 +9,8 @@ import Footer from "./partials/Footer";
 import Skills from "./partials/Skills";
 import KonamiCode from "./partials/KonamiCode";
 import Voucher from "./partials/Voucher";
+import DotaHome from "./pages/DotaHome";
+import DotaPlayer from "./pages/DotaPlayer";
 
 import data from "./assets/data";
 import konamiImage from "./images/pangolier.png";
@@ -61,6 +63,8 @@ const App = () => {
             <Routes>
                 <Route path="/" element={<Home />} />
                 <Route path="/voucher" element={<Voucher />} />
+                <Route path="/dota" element={<DotaHome />} />
+                <Route path="/dota/player/:steamId" element={<DotaPlayer />} />
             </Routes>
         </Router>
     );

--- a/src/assets/data.js
+++ b/src/assets/data.js
@@ -13,8 +13,8 @@ const data = {
         medium: "https://medium.com/@lucas.sbaldin",
     },
     dota: {
-        name: "Lucas Baldin",
-        steamId: "76561198047007146",
+        name: "Bald3",
+        steamId: "132423849",
     },
     skills: [
         {

--- a/src/assets/data.js
+++ b/src/assets/data.js
@@ -12,6 +12,10 @@ const data = {
         email: "lucas.sbaldin@gmail.com",
         medium: "https://medium.com/@lucas.sbaldin",
     },
+    dota: {
+        name: "Lucas Baldin",
+        steamId: "76561198047007146",
+    },
     skills: [
         {
             skillName: "Backend",

--- a/src/pages/DotaHome.js
+++ b/src/pages/DotaHome.js
@@ -31,7 +31,7 @@ const DotaHome = () => {
             <section className="max-w-5xl mx-auto space-y-8">
                 <header className="bg-gray-800 rounded-2xl p-6 shadow-xl border border-gray-700">
                     <img
-                        src="https://cdn.cloudflare.steamstatic.com/apps/dota2/images/dota_react/home/logo.png"
+                        src="https://cdn.cloudflare.steamstatic.com/apps/dota2/images/dota_react/dota_footer_logo.png"
                         alt="Dota 2"
                         className="h-12 md:h-16"
                     />
@@ -58,7 +58,7 @@ const DotaHome = () => {
                             onChange={(event) =>
                                 setSearchValue(event.target.value)
                             }
-                            placeholder="Ex: 76561198047007146"
+                            placeholder="Ex: 1234567890"
                             className="w-full rounded-xl px-4 py-3 text-gray-900"
                         />
                         <button

--- a/src/pages/DotaHome.js
+++ b/src/pages/DotaHome.js
@@ -1,0 +1,103 @@
+import React, { useState } from "react";
+import { useNavigate } from "react-router-dom";
+
+import data from "../assets/data";
+import { buildDotaPlayerPath } from "../utils/dota";
+
+const DotaHome = () => {
+    const navigate = useNavigate();
+    const [searchValue, setSearchValue] = useState("");
+    const [error, setError] = useState("");
+
+    const goToPlayer = (steamId) => {
+        const path = buildDotaPlayerPath(steamId);
+
+        if (!path) {
+            setError("Digite um Steam ID válido para continuar.");
+            return;
+        }
+
+        setError("");
+        navigate(path);
+    };
+
+    const handleSearch = (event) => {
+        event.preventDefault();
+        goToPlayer(searchValue);
+    };
+
+    return (
+        <main className="min-h-screen bg-gray-900 text-gray-100 px-4 py-10">
+            <section className="max-w-5xl mx-auto space-y-8">
+                <header className="bg-gray-800 rounded-2xl p-6 shadow-xl border border-gray-700">
+                    <img
+                        src="https://cdn.cloudflare.steamstatic.com/apps/dota2/images/dota_react/home/logo.png"
+                        alt="Dota 2"
+                        className="h-12 md:h-16"
+                    />
+                    <p className="mt-4 text-gray-300 leading-relaxed">
+                        Bem-vindo ao ecossistema de Dota 2. Aqui você pode
+                        buscar perfis de jogadores, conferir ranking, últimas
+                        partidas e evoluir para novas páginas com heróis,
+                        estatísticas e análises.
+                    </p>
+                </header>
+
+                <form
+                    onSubmit={handleSearch}
+                    className="bg-gray-800 rounded-2xl p-6 shadow-xl border border-gray-700"
+                >
+                    <label htmlFor="steam-search" className="block mb-3">
+                        Buscar jogador por Steam ID (ou account_id)
+                    </label>
+                    <div className="flex flex-col md:flex-row gap-3">
+                        <input
+                            id="steam-search"
+                            type="text"
+                            value={searchValue}
+                            onChange={(event) =>
+                                setSearchValue(event.target.value)
+                            }
+                            placeholder="Ex: 76561198047007146"
+                            className="w-full rounded-xl px-4 py-3 text-gray-900"
+                        />
+                        <button
+                            type="submit"
+                            className="bg-red-600 hover:bg-red-500 rounded-xl px-6 py-3 font-semibold"
+                        >
+                            Buscar
+                        </button>
+                    </div>
+                    {error && <p className="mt-3 text-red-400">{error}</p>}
+                </form>
+
+                <article
+                    role="button"
+                    tabIndex={0}
+                    onClick={() => goToPlayer(data.dota.steamId)}
+                    onKeyDown={(event) => {
+                        if (event.key === "Enter" || event.key === " ") {
+                            goToPlayer(data.dota.steamId);
+                        }
+                    }}
+                    className="bg-gray-800 rounded-2xl p-6 shadow-xl border border-gray-700 cursor-pointer hover:border-red-500 transition"
+                >
+                    <p className="text-sm uppercase tracking-wider text-gray-400">
+                        Meu perfil Steam
+                    </p>
+                    <h2 className="text-2xl font-bold mt-2">
+                        {data.dota.name}
+                    </h2>
+                    <p className="text-gray-300 mt-1">
+                        Steam ID: {data.dota.steamId}
+                    </p>
+                    <p className="text-red-400 mt-4">
+                        Clique para abrir perfil
+                    </p>
+                </article>
+            </section>
+        </main>
+    );
+};
+
+export default DotaHome;

--- a/src/pages/DotaPlayer.js
+++ b/src/pages/DotaPlayer.js
@@ -1,0 +1,156 @@
+import React, { useEffect, useState } from "react";
+import { Link, useParams } from "react-router-dom";
+
+import { rankTierLabel } from "../utils/dota";
+
+const DotaPlayer = () => {
+    const { steamId } = useParams();
+    const [player, setPlayer] = useState(null);
+    const [recentMatches, setRecentMatches] = useState([]);
+    const [loading, setLoading] = useState(true);
+    const [error, setError] = useState("");
+
+    useEffect(() => {
+        const controller = new AbortController();
+
+        const loadPlayerData = async () => {
+            setLoading(true);
+            setError("");
+
+            try {
+                const [profileResponse, matchesResponse] = await Promise.all([
+                    fetch(`https://api.opendota.com/api/players/${steamId}`, {
+                        signal: controller.signal,
+                    }),
+                    fetch(
+                        `https://api.opendota.com/api/players/${steamId}/recentMatches`,
+                        {
+                            signal: controller.signal,
+                        }
+                    ),
+                ]);
+
+                if (!profileResponse.ok || !matchesResponse.ok) {
+                    throw new Error("Falha ao carregar dados do jogador.");
+                }
+
+                const [playerData, matchesData] = await Promise.all([
+                    profileResponse.json(),
+                    matchesResponse.json(),
+                ]);
+
+                setPlayer(playerData);
+                setRecentMatches(matchesData.slice(0, 10));
+            } catch (requestError) {
+                if (requestError.name !== "AbortError") {
+                    setError(
+                        "Não foi possível carregar os dados do jogador no momento."
+                    );
+                }
+            } finally {
+                setLoading(false);
+            }
+        };
+
+        loadPlayerData();
+
+        return () => controller.abort();
+    }, [steamId]);
+
+    return (
+        <main className="min-h-screen bg-gray-900 text-gray-100 px-4 py-10">
+            <section className="max-w-6xl mx-auto space-y-6">
+                <Link to="/dota" className="text-red-400 hover:text-red-300">
+                    ← Voltar para /dota
+                </Link>
+
+                {loading && <p>Carregando dados do player...</p>}
+                {error && <p className="text-red-400">{error}</p>}
+
+                {!loading && !error && player && (
+                    <>
+                        <header className="bg-gray-800 rounded-2xl p-6 border border-gray-700 shadow-xl">
+                            <h1 className="text-3xl font-bold">
+                                {player.profile?.personaname ||
+                                    "Jogador sem nome"}
+                            </h1>
+                            <p className="text-gray-300 mt-2">
+                                Rank: {rankTierLabel(player.rank_tier)}
+                            </p>
+                            <p className="text-gray-300">
+                                MMR estimado:{" "}
+                                {player.mmr_estimate?.estimate || "N/A"}
+                            </p>
+                            {player.profile?.avatarmedium && (
+                                <img
+                                    src={player.profile.avatarmedium}
+                                    alt={player.profile.personaname}
+                                    className="mt-4 rounded-full w-24 h-24"
+                                />
+                            )}
+                        </header>
+
+                        <section className="bg-gray-800 rounded-2xl p-6 border border-gray-700 shadow-xl">
+                            <h2 className="text-2xl font-semibold mb-4">
+                                Últimas partidas
+                            </h2>
+                            <div className="overflow-x-auto">
+                                <table className="w-full text-left text-sm">
+                                    <thead>
+                                        <tr className="text-gray-400 border-b border-gray-700">
+                                            <th className="py-2">Match</th>
+                                            <th className="py-2">Hero ID</th>
+                                            <th className="py-2">K / D / A</th>
+                                            <th className="py-2">Resultado</th>
+                                        </tr>
+                                    </thead>
+                                    <tbody>
+                                        {recentMatches.map((match) => {
+                                            const won =
+                                                (match.player_slot < 128 &&
+                                                    match.radiant_win) ||
+                                                (match.player_slot >= 128 &&
+                                                    !match.radiant_win);
+
+                                            return (
+                                                <tr
+                                                    key={match.match_id}
+                                                    className="border-b border-gray-700"
+                                                >
+                                                    <td className="py-2">
+                                                        {match.match_id}
+                                                    </td>
+                                                    <td className="py-2">
+                                                        {match.hero_id}
+                                                    </td>
+                                                    <td className="py-2">
+                                                        {match.kills} /{" "}
+                                                        {match.deaths} /{" "}
+                                                        {match.assists}
+                                                    </td>
+                                                    <td
+                                                        className={`py-2 ${
+                                                            won
+                                                                ? "text-green-400"
+                                                                : "text-red-400"
+                                                        }`}
+                                                    >
+                                                        {won
+                                                            ? "Vitória"
+                                                            : "Derrota"}
+                                                    </td>
+                                                </tr>
+                                            );
+                                        })}
+                                    </tbody>
+                                </table>
+                            </div>
+                        </section>
+                    </>
+                )}
+            </section>
+        </main>
+    );
+};
+
+export default DotaPlayer;

--- a/src/utils/dota.js
+++ b/src/utils/dota.js
@@ -1,0 +1,78 @@
+const STEAM_ACCOUNT_OFFSET = "76561197960265728";
+
+const subtractLargeNumbers = (value, offset) => {
+    let carry = 0;
+    let result = "";
+
+    const a = value.split("").reverse();
+    const b = offset.split("").reverse();
+
+    for (let index = 0; index < a.length; index += 1) {
+        const digitA = Number(a[index] || 0);
+        const digitB = Number(b[index] || 0);
+
+        let subtraction = digitA - digitB - carry;
+
+        if (subtraction < 0) {
+            subtraction += 10;
+            carry = 1;
+        } else {
+            carry = 0;
+        }
+
+        result = `${subtraction}${result}`;
+    }
+
+    return result.replace(/^0+/, "") || "0";
+};
+
+export const steamIdToAccountId = (steamId) => {
+    if (!steamId) {
+        return null;
+    }
+
+    const cleanId = `${steamId}`.trim();
+
+    if (!/^\d+$/.test(cleanId)) {
+        return null;
+    }
+
+    if (cleanId.length > 10) {
+        const accountId = subtractLargeNumbers(cleanId, STEAM_ACCOUNT_OFFSET);
+        return Number(accountId);
+    }
+
+    return Number(cleanId);
+};
+
+export const buildDotaPlayerPath = (steamId) => {
+    const accountId = steamIdToAccountId(steamId);
+
+    if (!accountId && accountId !== 0) {
+        return null;
+    }
+
+    return `/dota/player/${accountId}`;
+};
+
+export const rankTierLabel = (rankTier) => {
+    if (!rankTier) {
+        return "Sem ranking calibrado";
+    }
+
+    const medalMap = {
+        1: "Herald",
+        2: "Guardian",
+        3: "Crusader",
+        4: "Archon",
+        5: "Legend",
+        6: "Ancient",
+        7: "Divine",
+        8: "Immortal",
+    };
+
+    const medal = Math.floor(rankTier / 10);
+    const stars = rankTier % 10;
+
+    return `${medalMap[medal] || "Unknown"}${stars ? ` ${stars}` : ""}`;
+};


### PR DESCRIPTION
### Motivation
- Criar um ecossistema inicial dedicado a Dota 2 dentro do site com uma página principal `/dota` e navegação para perfis de jogador. 
- Permitir busca por SteamID/AccountID e exibir rapidamente o perfil próprio via um card clicável. 
- Consumir a OpenDota API para mostrar informações de jogador (perfil, MMR estimado, rank) e últimas partidas.

### Description
- Adiciona rotas em `src/App.js` para `/dota` e `/dota/player/:steamId` e registra as novas páginas `DotaHome` e `DotaPlayer`.
- Cria `src/pages/DotaHome.js` com logo do Dota, descrição, formulário de busca por Steam ID/account_id e card clicável do perfil configurado em `data.js`.
- Cria `src/pages/DotaPlayer.js` que carrega `https://api.opendota.com/api/players/{account_id}` e `.../recentMatches` para exibir nome, rank (formatado), MMR estimado, avatar e tabela com últimas partidas.
- Implementa utilitários em `src/utils/dota.js` para converter SteamID64 em `account_id` sem usar `BigInt` (subtração de strings), montar a rota do player com `buildDotaPlayerPath` e formatar `rank_tier` em um rótulo legível.
- Adiciona dados iniciais do perfil Dota em `src/assets/data.js` (`dota.name` e `dota.steamId`) para popular o card na home.

### Testing
- Executado `npm run build` que compilou com sucesso e gerou o build de produção sem erros.
- Executado `CI=true npm test -- --watch=false` e todos os testes automatizados passaram (1 test suite, 1 test passado).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699df50c68a48326901679486e589209)