### PR TITLE
Add Dota 2 pages and utilities (player, match, home)

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -12,6 +12,7 @@ import Voucher from "./partials/Voucher";
 import DotaHome from "./pages/DotaHome";
 import DotaPlayer from "./pages/DotaPlayer";
 import DotaMatch from "./pages/DotaMatch";
+import DotaHeroes from "./pages/DotaHeroes";
 
 import data from "./assets/data";
 import konamiImage from "./images/pangolier.png";
@@ -65,6 +66,7 @@ const App = () => {
                 <Route path="/" element={<Home />} />
                 <Route path="/voucher" element={<Voucher />} />
                 <Route path="/dota" element={<DotaHome />} />
+                <Route path="/dota/heroes" element={<DotaHeroes />} />
                 <Route path="/dota/player/:steamId" element={<DotaPlayer />} />
                 <Route
                     path="/dota/player/:steamId/match/:matchId"

--- a/src/App.js
+++ b/src/App.js
@@ -9,6 +9,9 @@ import Footer from "./partials/Footer";
 import Skills from "./partials/Skills";
 import KonamiCode from "./partials/KonamiCode";
 import Voucher from "./partials/Voucher";
+import DotaHome from "./pages/DotaHome";
+import DotaPlayer from "./pages/DotaPlayer";
+import DotaMatch from "./pages/DotaMatch";
 
 import data from "./assets/data";
 import konamiImage from "./images/pangolier.png";
@@ -61,6 +64,12 @@ const App = () => {
             <Routes>
                 <Route path="/" element={<Home />} />
                 <Route path="/voucher" element={<Voucher />} />
+                <Route path="/dota" element={<DotaHome />} />
+                <Route path="/dota/player/:steamId" element={<DotaPlayer />} />
+                <Route
+                    path="/dota/player/:steamId/match/:matchId"
+                    element={<DotaMatch />}
+                />
             </Routes>
         </Router>
     );

--- a/src/App.js
+++ b/src/App.js
@@ -13,6 +13,7 @@ import DotaHome from "./pages/DotaHome";
 import DotaPlayer from "./pages/DotaPlayer";
 import DotaMatch from "./pages/DotaMatch";
 import DotaHeroes from "./pages/DotaHeroes";
+import DotaHeroDetail from "./pages/DotaHeroDetail";
 
 import data from "./assets/data";
 import konamiImage from "./images/pangolier.png";
@@ -67,6 +68,10 @@ const App = () => {
                 <Route path="/voucher" element={<Voucher />} />
                 <Route path="/dota" element={<DotaHome />} />
                 <Route path="/dota/heroes" element={<DotaHeroes />} />
+                <Route
+                    path="/dota/heroes/:heroId"
+                    element={<DotaHeroDetail />}
+                />
                 <Route path="/dota/player/:steamId" element={<DotaPlayer />} />
                 <Route
                     path="/dota/player/:steamId/match/:matchId"

--- a/src/assets/data.js
+++ b/src/assets/data.js
@@ -13,8 +13,8 @@ const data = {
         medium: "https://medium.com/@lucas.sbaldin",
     },
     dota: {
-        name: "Lucas Baldin",
-        steamId: "76561198047007146",
+        name: "Bald3 バケツ",
+        steamId: "132423849",
     },
     skills: [
         {

--- a/src/assets/data.js
+++ b/src/assets/data.js
@@ -12,6 +12,10 @@ const data = {
         email: "lucas.sbaldin@gmail.com",
         medium: "https://medium.com/@lucas.sbaldin",
     },
+    dota: {
+        name: "Lucas Baldin",
+        steamId: "76561198047007146",
+    },
     skills: [
         {
             skillName: "Backend",

--- a/src/pages/DotaHeroDetail.js
+++ b/src/pages/DotaHeroDetail.js
@@ -1,0 +1,156 @@
+import React, { useEffect, useState } from "react";
+import { Link, useParams } from "react-router-dom";
+
+import { fetchHeroesMap } from "../utils/dota";
+
+const StatCard = ({ label, value }) => (
+    <div className="bg-gray-700/60 rounded-xl p-3 border border-gray-600">
+        <p className="text-xs uppercase tracking-wide text-gray-400">{label}</p>
+        <p className="text-lg font-semibold mt-1">{value ?? "N/A"}</p>
+    </div>
+);
+
+const DotaHeroDetail = () => {
+    const { heroId } = useParams();
+    const [hero, setHero] = useState(null);
+    const [loading, setLoading] = useState(true);
+    const [error, setError] = useState("");
+
+    useEffect(() => {
+        const controller = new AbortController();
+
+        const loadHero = async () => {
+            setLoading(true);
+            setError("");
+
+            try {
+                const heroesMap = await fetchHeroesMap(controller.signal);
+                const selectedHero = heroesMap[heroId];
+
+                if (!selectedHero) {
+                    setError("Herói não encontrado.");
+                    return;
+                }
+
+                setHero(selectedHero);
+            } catch (requestError) {
+                if (requestError.name !== "AbortError") {
+                    setError("Não foi possível carregar os detalhes do herói.");
+                }
+            } finally {
+                setLoading(false);
+            }
+        };
+
+        loadHero();
+
+        return () => controller.abort();
+    }, [heroId]);
+
+    return (
+        <main className="min-h-screen bg-gray-900 text-gray-100 px-4 py-10">
+            <section className="max-w-5xl mx-auto space-y-6">
+                <div className="flex gap-4">
+                    <Link
+                        to="/dota/heroes"
+                        className="text-red-400 hover:text-red-300"
+                    >
+                        ← Voltar para heróis
+                    </Link>
+                    <Link
+                        to="/dota"
+                        className="text-red-400 hover:text-red-300"
+                    >
+                        Ir para /dota
+                    </Link>
+                </div>
+
+                {loading && <p>Carregando herói...</p>}
+                {error && <p className="text-red-400">{error}</p>}
+
+                {!loading && !error && hero && (
+                    <>
+                        <header className="bg-gray-800 rounded-2xl border border-gray-700 shadow-xl overflow-hidden">
+                            {hero.image ? (
+                                <img
+                                    src={hero.image}
+                                    alt={hero.name}
+                                    className="w-full h-56 object-cover"
+                                />
+                            ) : (
+                                <div className="w-full h-56 bg-gray-700" />
+                            )}
+                            <div className="p-6">
+                                <div className="flex items-center gap-3">
+                                    {hero.icon ? (
+                                        <img
+                                            src={hero.icon}
+                                            alt={hero.name}
+                                            className="w-12 h-12 rounded"
+                                        />
+                                    ) : null}
+                                    <h1 className="text-3xl font-bold">
+                                        {hero.name}
+                                    </h1>
+                                </div>
+                                <p className="text-gray-300 mt-3">
+                                    {hero.lore}
+                                </p>
+                            </div>
+                        </header>
+
+                        <section className="bg-gray-800 rounded-2xl p-6 border border-gray-700 shadow-xl">
+                            <h2 className="text-2xl font-semibold mb-4">
+                                Informações básicas
+                            </h2>
+                            <div className="grid sm:grid-cols-2 lg:grid-cols-3 gap-3">
+                                <StatCard
+                                    label="Atributo primário"
+                                    value={hero.primaryAttr}
+                                />
+                                <StatCard
+                                    label="Tipo de ataque"
+                                    value={hero.attackType}
+                                />
+                                <StatCard
+                                    label="Funções"
+                                    value={
+                                        hero.roles.length
+                                            ? hero.roles.join(", ")
+                                            : "N/A"
+                                    }
+                                />
+                                <StatCard
+                                    label="Vida base"
+                                    value={hero.baseHealth}
+                                />
+                                <StatCard
+                                    label="Mana base"
+                                    value={hero.baseMana}
+                                />
+                                <StatCard
+                                    label="Armadura base"
+                                    value={hero.baseArmor}
+                                />
+                                <StatCard
+                                    label="Ataque base"
+                                    value={`${hero.baseAttackMin} - ${hero.baseAttackMax}`}
+                                />
+                                <StatCard
+                                    label="Velocidade de movimento"
+                                    value={hero.moveSpeed}
+                                />
+                                <StatCard
+                                    label="Ganho STR / AGI / INT"
+                                    value={`${hero.strGain} / ${hero.agiGain} / ${hero.intGain}`}
+                                />
+                            </div>
+                        </section>
+                    </>
+                )}
+            </section>
+        </main>
+    );
+};
+
+export default DotaHeroDetail;

--- a/src/pages/DotaHeroes.js
+++ b/src/pages/DotaHeroes.js
@@ -1,7 +1,7 @@
 import React, { useEffect, useMemo, useState } from "react";
 import { Link } from "react-router-dom";
 
-import { fetchHeroesMap } from "../utils/dota";
+import { fetchHeroesMap, getHeroPath } from "../utils/dota";
 
 const DotaHeroes = () => {
     const [heroesMap, setHeroesMap] = useState({});
@@ -65,7 +65,8 @@ const DotaHeroes = () => {
                 <header className="bg-gray-800 rounded-2xl p-6 border border-gray-700 shadow-xl">
                     <h1 className="text-3xl font-bold">Heróis de Dota 2</h1>
                     <p className="text-gray-300 mt-2">
-                        Catálogo de heróis com busca rápida por nome.
+                        Clique no herói para abrir detalhes, lore e status
+                        básicos.
                     </p>
 
                     <div className="mt-4">
@@ -89,9 +90,10 @@ const DotaHeroes = () => {
                 {!loading && !error && (
                     <section className="grid sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-4">
                         {filteredHeroes.map((hero) => (
-                            <article
+                            <Link
                                 key={hero.id}
-                                className="bg-gray-800 rounded-2xl border border-gray-700 shadow-xl overflow-hidden"
+                                to={getHeroPath(hero.id)}
+                                className="block bg-gray-800 rounded-2xl border border-gray-700 shadow-xl overflow-hidden hover:border-red-500 transition"
                             >
                                 {hero.image ? (
                                     <img
@@ -118,7 +120,7 @@ const DotaHeroes = () => {
                                         </h2>
                                     </div>
                                 </div>
-                            </article>
+                            </Link>
                         ))}
                     </section>
                 )}

--- a/src/pages/DotaHeroes.js
+++ b/src/pages/DotaHeroes.js
@@ -1,0 +1,130 @@
+import React, { useEffect, useMemo, useState } from "react";
+import { Link } from "react-router-dom";
+
+import { fetchHeroesMap } from "../utils/dota";
+
+const DotaHeroes = () => {
+    const [heroesMap, setHeroesMap] = useState({});
+    const [search, setSearch] = useState("");
+    const [loading, setLoading] = useState(true);
+    const [error, setError] = useState("");
+
+    useEffect(() => {
+        const controller = new AbortController();
+
+        const loadHeroes = async () => {
+            setLoading(true);
+            setError("");
+
+            try {
+                const data = await fetchHeroesMap(controller.signal);
+                setHeroesMap(data);
+            } catch (requestError) {
+                if (requestError.name !== "AbortError") {
+                    setError("Não foi possível carregar os heróis no momento.");
+                }
+            } finally {
+                setLoading(false);
+            }
+        };
+
+        loadHeroes();
+
+        return () => controller.abort();
+    }, []);
+
+    const filteredHeroes = useMemo(() => {
+        const normalizedSearch = search.trim().toLowerCase();
+
+        return Object.values(heroesMap)
+            .sort((a, b) => a.name.localeCompare(b.name))
+            .filter((hero) => {
+                if (!normalizedSearch) {
+                    return true;
+                }
+
+                return hero.name.toLowerCase().includes(normalizedSearch);
+            });
+    }, [heroesMap, search]);
+
+    return (
+        <main className="min-h-screen bg-gray-900 text-gray-100 px-4 py-10">
+            <section className="max-w-7xl mx-auto space-y-6">
+                <div className="flex flex-wrap gap-4 items-center justify-between">
+                    <Link
+                        to="/dota"
+                        className="text-red-400 hover:text-red-300"
+                    >
+                        ← Voltar para /dota
+                    </Link>
+                    <span className="text-gray-400 text-sm">
+                        {filteredHeroes.length} heróis encontrados
+                    </span>
+                </div>
+
+                <header className="bg-gray-800 rounded-2xl p-6 border border-gray-700 shadow-xl">
+                    <h1 className="text-3xl font-bold">Heróis de Dota 2</h1>
+                    <p className="text-gray-300 mt-2">
+                        Catálogo de heróis com busca rápida por nome.
+                    </p>
+
+                    <div className="mt-4">
+                        <label htmlFor="hero-search" className="block mb-2">
+                            Buscar herói
+                        </label>
+                        <input
+                            id="hero-search"
+                            type="text"
+                            value={search}
+                            onChange={(event) => setSearch(event.target.value)}
+                            placeholder="Ex: Pudge, Invoker, Crystal Maiden..."
+                            className="w-full md:w-2/3 rounded-xl px-4 py-3 text-gray-900"
+                        />
+                    </div>
+                </header>
+
+                {loading && <p>Carregando heróis...</p>}
+                {error && <p className="text-red-400">{error}</p>}
+
+                {!loading && !error && (
+                    <section className="grid sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-4">
+                        {filteredHeroes.map((hero) => (
+                            <article
+                                key={hero.id}
+                                className="bg-gray-800 rounded-2xl border border-gray-700 shadow-xl overflow-hidden"
+                            >
+                                {hero.image ? (
+                                    <img
+                                        src={hero.image}
+                                        alt={hero.name}
+                                        className="w-full h-32 object-cover"
+                                    />
+                                ) : (
+                                    <div className="w-full h-32 bg-gray-700" />
+                                )}
+                                <div className="p-4">
+                                    <div className="flex items-center gap-2">
+                                        {hero.icon ? (
+                                            <img
+                                                src={hero.icon}
+                                                alt={hero.name}
+                                                className="w-8 h-8 rounded"
+                                            />
+                                        ) : (
+                                            <div className="w-8 h-8 rounded bg-gray-700" />
+                                        )}
+                                        <h2 className="text-lg font-semibold">
+                                            {hero.name}
+                                        </h2>
+                                    </div>
+                                </div>
+                            </article>
+                        ))}
+                    </section>
+                )}
+            </section>
+        </main>
+    );
+};
+
+export default DotaHeroes;

--- a/src/pages/DotaHome.js
+++ b/src/pages/DotaHome.js
@@ -1,5 +1,5 @@
 import React, { useState } from "react";
-import { useNavigate } from "react-router-dom";
+import { Link, useNavigate } from "react-router-dom";
 
 import data from "../assets/data";
 import { buildDotaPlayerPath } from "../utils/dota";
@@ -70,6 +70,20 @@ const DotaHome = () => {
                     </div>
                     {error && <p className="mt-3 text-red-400">{error}</p>}
                 </form>
+
+                <section className="bg-gray-800 rounded-2xl p-6 shadow-xl border border-gray-700">
+                    <h2 className="text-2xl font-semibold">Explorar heróis</h2>
+                    <p className="text-gray-300 mt-2">
+                        Navegue pelo catálogo de heróis com imagens e busca por
+                        nome.
+                    </p>
+                    <Link
+                        to="/dota/heroes"
+                        className="inline-block mt-4 bg-red-600 hover:bg-red-500 rounded-xl px-5 py-3 font-semibold"
+                    >
+                        Abrir página de heróis
+                    </Link>
+                </section>
 
                 <article
                     role="button"

--- a/src/pages/DotaHome.js
+++ b/src/pages/DotaHome.js
@@ -31,7 +31,7 @@ const DotaHome = () => {
             <section className="max-w-5xl mx-auto space-y-8">
                 <header className="bg-gray-800 rounded-2xl p-6 shadow-xl border border-gray-700">
                     <img
-                        src="https://cdn.cloudflare.steamstatic.com/apps/dota2/images/dota_react/home/logo.png"
+                        src="https://cdn.cloudflare.steamstatic.com/apps/dota2/images/dota_react/dota_footer_logo.png"
                         alt="Dota 2"
                         className="h-12 md:h-16"
                     />

--- a/src/pages/DotaHome.js
+++ b/src/pages/DotaHome.js
@@ -1,0 +1,103 @@
+import React, { useState } from "react";
+import { useNavigate } from "react-router-dom";
+
+import data from "../assets/data";
+import { buildDotaPlayerPath } from "../utils/dota";
+
+const DotaHome = () => {
+    const navigate = useNavigate();
+    const [searchValue, setSearchValue] = useState("");
+    const [error, setError] = useState("");
+
+    const goToPlayer = (steamId) => {
+        const path = buildDotaPlayerPath(steamId);
+
+        if (!path) {
+            setError("Digite um Steam ID válido para continuar.");
+            return;
+        }
+
+        setError("");
+        navigate(path);
+    };
+
+    const handleSearch = (event) => {
+        event.preventDefault();
+        goToPlayer(searchValue);
+    };
+
+    return (
+        <main className="min-h-screen bg-gray-900 text-gray-100 px-4 py-10">
+            <section className="max-w-5xl mx-auto space-y-8">
+                <header className="bg-gray-800 rounded-2xl p-6 shadow-xl border border-gray-700">
+                    <img
+                        src="https://cdn.cloudflare.steamstatic.com/apps/dota2/images/dota_react/home/logo.png"
+                        alt="Dota 2"
+                        className="h-12 md:h-16"
+                    />
+                    <p className="mt-4 text-gray-300 leading-relaxed">
+                        Bem-vindo ao ecossistema de Dota 2. Aqui você pode
+                        buscar perfis de jogadores, conferir ranking, últimas
+                        partidas e evoluir para novas páginas com heróis,
+                        estatísticas e análises.
+                    </p>
+                </header>
+
+                <form
+                    onSubmit={handleSearch}
+                    className="bg-gray-800 rounded-2xl p-6 shadow-xl border border-gray-700"
+                >
+                    <label htmlFor="steam-search" className="block mb-3">
+                        Buscar jogador por Steam ID (ou account_id)
+                    </label>
+                    <div className="flex flex-col md:flex-row gap-3">
+                        <input
+                            id="steam-search"
+                            type="text"
+                            value={searchValue}
+                            onChange={(event) =>
+                                setSearchValue(event.target.value)
+                            }
+                            placeholder="Ex: 76561198047007146"
+                            className="w-full rounded-xl px-4 py-3 text-gray-900"
+                        />
+                        <button
+                            type="submit"
+                            className="bg-red-600 hover:bg-red-500 rounded-xl px-6 py-3 font-semibold"
+                        >
+                            Buscar
+                        </button>
+                    </div>
+                    {error && <p className="mt-3 text-red-400">{error}</p>}
+                </form>
+
+                <article
+                    role="button"
+                    tabIndex={0}
+                    onClick={() => goToPlayer(data.dota.steamId)}
+                    onKeyDown={(event) => {
+                        if (event.key === "Enter" || event.key === " ") {
+                            goToPlayer(data.dota.steamId);
+                        }
+                    }}
+                    className="bg-gray-800 rounded-2xl p-6 shadow-xl border border-gray-700 cursor-pointer hover:border-red-500 transition"
+                >
+                    <p className="text-sm uppercase tracking-wider text-gray-400">
+                        Meu perfil Steam
+                    </p>
+                    <h2 className="text-2xl font-bold mt-2">
+                        {data.dota.name}
+                    </h2>
+                    <p className="text-gray-300 mt-1">
+                        Steam ID: {data.dota.steamId}
+                    </p>
+                    <p className="text-red-400 mt-4">
+                        Clique para abrir perfil
+                    </p>
+                </article>
+            </section>
+        </main>
+    );
+};
+
+export default DotaHome;

--- a/src/pages/DotaMatch.js
+++ b/src/pages/DotaMatch.js
@@ -1,0 +1,224 @@
+import React, { useEffect, useMemo, useState } from "react";
+import { Link, useParams } from "react-router-dom";
+
+import {
+    didPlayerWin,
+    fetchHeroesMap,
+    formatDateTime,
+    formatDuration,
+    isRadiantPlayer,
+} from "../utils/dota";
+
+const TeamTable = ({ title, players, heroesMap, radiantWin }) => (
+    <section className="bg-gray-800 rounded-2xl p-6 border border-gray-700 shadow-xl">
+        <h2 className="text-2xl font-semibold mb-4">{title}</h2>
+        <div className="overflow-x-auto">
+            <table className="w-full text-left text-sm">
+                <thead>
+                    <tr className="text-gray-400 border-b border-gray-700">
+                        <th className="py-2">Herói</th>
+                        <th className="py-2">Jogador</th>
+                        <th className="py-2">K / D / A</th>
+                        <th className="py-2">LH / DN</th>
+                        <th className="py-2">GPM / XPM</th>
+                        <th className="py-2">Dano em herói</th>
+                        <th className="py-2">Resultado</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    {players.map((player) => {
+                        const hero = heroesMap[player.hero_id];
+                        const won = didPlayerWin(
+                            player.player_slot,
+                            radiantWin
+                        );
+
+                        return (
+                            <tr
+                                key={`${player.account_id || "anon"}-${player.hero_id}-${player.player_slot}`}
+                                className="border-b border-gray-700"
+                            >
+                                <td className="py-2">
+                                    <div className="flex items-center gap-2">
+                                        {hero?.icon ? (
+                                            <img
+                                                src={hero.icon}
+                                                alt={hero.name}
+                                                className="w-8 h-8 rounded"
+                                            />
+                                        ) : (
+                                            <div className="w-8 h-8 rounded bg-gray-700" />
+                                        )}
+                                        <span>
+                                            {hero?.name ||
+                                                `Hero #${player.hero_id}`}
+                                        </span>
+                                    </div>
+                                </td>
+                                <td className="py-2">
+                                    {player.personaname || "Anônimo"}
+                                </td>
+                                <td className="py-2">
+                                    {player.kills} / {player.deaths} /{" "}
+                                    {player.assists}
+                                </td>
+                                <td className="py-2">
+                                    {player.last_hits} / {player.denies}
+                                </td>
+                                <td className="py-2">
+                                    {player.gold_per_min} / {player.xp_per_min}
+                                </td>
+                                <td className="py-2">
+                                    {player.hero_damage || 0}
+                                </td>
+                                <td
+                                    className={`py-2 ${
+                                        won ? "text-green-400" : "text-red-400"
+                                    }`}
+                                >
+                                    {won ? "Vitória" : "Derrota"}
+                                </td>
+                            </tr>
+                        );
+                    })}
+                </tbody>
+            </table>
+        </div>
+    </section>
+);
+
+const DotaMatch = () => {
+    const { steamId, matchId } = useParams();
+    const [match, setMatch] = useState(null);
+    const [heroesMap, setHeroesMap] = useState({});
+    const [loading, setLoading] = useState(true);
+    const [error, setError] = useState("");
+
+    useEffect(() => {
+        const controller = new AbortController();
+
+        const loadMatchData = async () => {
+            setLoading(true);
+            setError("");
+
+            try {
+                const [matchResponse, heroesData] = await Promise.all([
+                    fetch(`https://api.opendota.com/api/matches/${matchId}`, {
+                        signal: controller.signal,
+                    }),
+                    fetchHeroesMap(controller.signal),
+                ]);
+
+                if (!matchResponse.ok) {
+                    throw new Error("Falha ao carregar partida");
+                }
+
+                const matchData = await matchResponse.json();
+                setMatch(matchData);
+                setHeroesMap(heroesData);
+            } catch (requestError) {
+                if (requestError.name !== "AbortError") {
+                    setError(
+                        "Não foi possível carregar os detalhes dessa partida."
+                    );
+                }
+            } finally {
+                setLoading(false);
+            }
+        };
+
+        loadMatchData();
+
+        return () => controller.abort();
+    }, [matchId]);
+
+    const { radiantPlayers, direPlayers } = useMemo(() => {
+        if (!match?.players) {
+            return { radiantPlayers: [], direPlayers: [] };
+        }
+
+        return {
+            radiantPlayers: match.players.filter((player) =>
+                isRadiantPlayer(player.player_slot)
+            ),
+            direPlayers: match.players.filter(
+                (player) => !isRadiantPlayer(player.player_slot)
+            ),
+        };
+    }, [match]);
+
+    return (
+        <main className="min-h-screen bg-gray-900 text-gray-100 px-4 py-10">
+            <section className="max-w-7xl mx-auto space-y-6">
+                <div className="flex flex-wrap gap-4">
+                    <Link
+                        to={`/dota/player/${steamId}`}
+                        className="text-red-400 hover:text-red-300"
+                    >
+                        ← Voltar para perfil
+                    </Link>
+                    <Link
+                        to="/dota"
+                        className="text-red-400 hover:text-red-300"
+                    >
+                        Ir para /dota
+                    </Link>
+                </div>
+
+                {loading && <p>Carregando partida...</p>}
+                {error && <p className="text-red-400">{error}</p>}
+
+                {!loading && !error && match && (
+                    <>
+                        <header className="bg-gray-800 rounded-2xl p-6 border border-gray-700 shadow-xl">
+                            <h1 className="text-3xl font-bold">
+                                Detalhes da partida #{match.match_id}
+                            </h1>
+                            <div className="mt-4 grid md:grid-cols-2 gap-3 text-gray-300">
+                                <p>
+                                    <strong>Vencedor:</strong>{" "}
+                                    {match.radiant_win ? "Radiant" : "Dire"}
+                                </p>
+                                <p>
+                                    <strong>Duração:</strong>{" "}
+                                    {formatDuration(match.duration)}
+                                </p>
+                                <p>
+                                    <strong>Início:</strong>{" "}
+                                    {formatDateTime(match.start_time)}
+                                </p>
+                                <p>
+                                    <strong>Game Mode:</strong>{" "}
+                                    {match.game_mode}
+                                </p>
+                                <p>
+                                    <strong>Lobby Type:</strong>{" "}
+                                    {match.lobby_type}
+                                </p>
+                                <p>
+                                    <strong>Patch:</strong>{" "}
+                                    {match.patch || "N/A"}
+                                </p>
+                            </div>
+                        </header>
+
+                        <TeamTable
+                            title="Radiant"
+                            players={radiantPlayers}
+                            heroesMap={heroesMap}
+                            radiantWin={match.radiant_win}
+                        />
+                        <TeamTable
+                            title="Dire"
+                            players={direPlayers}
+                            heroesMap={heroesMap}
+                            radiantWin={match.radiant_win}
+                        />
+                    </>
+                )}
+            </section>
+        </main>
+    );
+};
+
+export default DotaMatch;

--- a/src/pages/DotaMatch.js
+++ b/src/pages/DotaMatch.js
@@ -1,15 +1,25 @@
 import React, { useEffect, useMemo, useState } from "react";
+import { FaCoins, FaTrophy } from "react-icons/fa";
+import {
+    GiBattleAxe,
+    GiBroadsword,
+    GiClockwork,
+    GiStarSwirl,
+} from "react-icons/gi";
 import { Link, useParams } from "react-router-dom";
 
 import {
-    didPlayerWin,
     fetchHeroesMap,
     formatDateTime,
     formatDuration,
+    getGameModeLabel,
+    getLobbyTypeLabel,
     isRadiantPlayer,
+    isRankedMatch,
+    isTurboMatch,
 } from "../utils/dota";
 
-const TeamTable = ({ title, players, heroesMap, radiantWin }) => (
+const TeamTable = ({ title, players, heroesMap }) => (
     <section className="bg-gray-800 rounded-2xl p-6 border border-gray-700 shadow-xl">
         <h2 className="text-2xl font-semibold mb-4">{title}</h2>
         <div className="overflow-x-auto">
@@ -20,18 +30,13 @@ const TeamTable = ({ title, players, heroesMap, radiantWin }) => (
                         <th className="py-2">Jogador</th>
                         <th className="py-2">K / D / A</th>
                         <th className="py-2">LH / DN</th>
-                        <th className="py-2">GPM / XPM</th>
-                        <th className="py-2">Dano em herói</th>
-                        <th className="py-2">Resultado</th>
+                        <th className="py-2">💰 GPM / ✨ XPM</th>
+                        <th className="py-2">⚔️ Dano em herói</th>
                     </tr>
                 </thead>
                 <tbody>
                     {players.map((player) => {
                         const hero = heroesMap[player.hero_id];
-                        const won = didPlayerWin(
-                            player.player_slot,
-                            radiantWin
-                        );
 
                         return (
                             <tr
@@ -66,17 +71,15 @@ const TeamTable = ({ title, players, heroesMap, radiantWin }) => (
                                     {player.last_hits} / {player.denies}
                                 </td>
                                 <td className="py-2">
-                                    {player.gold_per_min} / {player.xp_per_min}
+                                    <div className="flex items-center gap-2">
+                                        <FaCoins className="text-yellow-400" />
+                                        <span>{player.gold_per_min}</span>
+                                        <GiStarSwirl className="text-blue-400 ml-1" />
+                                        <span>{player.xp_per_min}</span>
+                                    </div>
                                 </td>
                                 <td className="py-2">
                                     {player.hero_damage || 0}
-                                </td>
-                                <td
-                                    className={`py-2 ${
-                                        won ? "text-green-400" : "text-red-400"
-                                    }`}
-                                >
-                                    {won ? "Vitória" : "Derrota"}
                                 </td>
                             </tr>
                         );
@@ -85,6 +88,18 @@ const TeamTable = ({ title, players, heroesMap, radiantWin }) => (
             </table>
         </div>
     </section>
+);
+
+const MatchBadge = ({ icon: Icon, label, value, valueClassName = "" }) => (
+    <div className="bg-gray-700/60 rounded-xl p-3 border border-gray-600">
+        <p className="text-xs uppercase tracking-wide text-gray-400 flex items-center gap-2">
+            <Icon />
+            {label}
+        </p>
+        <p className={`text-lg font-semibold mt-1 ${valueClassName}`}>
+            {value}
+        </p>
+    </div>
 );
 
 const DotaMatch = () => {
@@ -174,45 +189,68 @@ const DotaMatch = () => {
                             <h1 className="text-3xl font-bold">
                                 Detalhes da partida #{match.match_id}
                             </h1>
-                            <div className="mt-4 grid md:grid-cols-2 gap-3 text-gray-300">
-                                <p>
-                                    <strong>Vencedor:</strong>{" "}
-                                    {match.radiant_win ? "Radiant" : "Dire"}
-                                </p>
-                                <p>
-                                    <strong>Duração:</strong>{" "}
-                                    {formatDuration(match.duration)}
-                                </p>
-                                <p>
-                                    <strong>Início:</strong>{" "}
-                                    {formatDateTime(match.start_time)}
-                                </p>
-                                <p>
-                                    <strong>Game Mode:</strong>{" "}
-                                    {match.game_mode}
-                                </p>
-                                <p>
-                                    <strong>Lobby Type:</strong>{" "}
-                                    {match.lobby_type}
-                                </p>
-                                <p>
-                                    <strong>Patch:</strong>{" "}
-                                    {match.patch || "N/A"}
-                                </p>
+                            <div className="mt-4 grid md:grid-cols-2 lg:grid-cols-3 gap-3">
+                                <MatchBadge
+                                    icon={FaTrophy}
+                                    label="Vencedor"
+                                    value={
+                                        match.radiant_win ? "Radiant" : "Dire"
+                                    }
+                                    valueClassName={
+                                        match.radiant_win
+                                            ? "text-green-400"
+                                            : "text-red-400"
+                                    }
+                                />
+                                <MatchBadge
+                                    icon={GiClockwork}
+                                    label="Duração"
+                                    value={formatDuration(match.duration)}
+                                />
+                                <MatchBadge
+                                    icon={GiBattleAxe}
+                                    label="Modo de jogo"
+                                    value={getGameModeLabel(match.game_mode)}
+                                />
+                                <MatchBadge
+                                    icon={GiBroadsword}
+                                    label="Tipo de lobby"
+                                    value={getLobbyTypeLabel(match.lobby_type)}
+                                />
+                                <MatchBadge
+                                    icon={GiStarSwirl}
+                                    label="Início da partida"
+                                    value={formatDateTime(match.start_time)}
+                                />
+                                <MatchBadge
+                                    icon={FaCoins}
+                                    label="Fila"
+                                    value={
+                                        isTurboMatch(match.game_mode)
+                                            ? "Turbo"
+                                            : isRankedMatch(match.lobby_type)
+                                              ? "Ranked"
+                                              : "Casual"
+                                    }
+                                />
                             </div>
                         </header>
 
                         <TeamTable
-                            title="Radiant"
+                            title={
+                                match.radiant_win
+                                    ? "Radiant (Vencedor)"
+                                    : "Radiant"
+                            }
                             players={radiantPlayers}
                             heroesMap={heroesMap}
-                            radiantWin={match.radiant_win}
                         />
                         <TeamTable
-                            title="Dire"
+                            title={
+                                !match.radiant_win ? "Dire (Vencedor)" : "Dire"
+                            }
                             players={direPlayers}
                             heroesMap={heroesMap}
-                            radiantWin={match.radiant_win}
                         />
                     </>
                 )}

--- a/src/pages/DotaMatch.js
+++ b/src/pages/DotaMatch.js
@@ -15,8 +15,6 @@ import {
     getGameModeLabel,
     getLobbyTypeLabel,
     isRadiantPlayer,
-    isRankedMatch,
-    isTurboMatch,
 } from "../utils/dota";
 
 const TeamTable = ({ title, players, heroesMap }) => (

--- a/src/pages/DotaMatch.js
+++ b/src/pages/DotaMatch.js
@@ -222,17 +222,6 @@ const DotaMatch = () => {
                                     label="Início da partida"
                                     value={formatDateTime(match.start_time)}
                                 />
-                                <MatchBadge
-                                    icon={FaCoins}
-                                    label="Fila"
-                                    value={
-                                        isTurboMatch(match.game_mode)
-                                            ? "Turbo"
-                                            : isRankedMatch(match.lobby_type)
-                                              ? "Ranked"
-                                              : "Casual"
-                                    }
-                                />
                             </div>
                         </header>
 

--- a/src/pages/DotaPlayer.js
+++ b/src/pages/DotaPlayer.js
@@ -1,0 +1,209 @@
+import React, { useEffect, useState } from "react";
+import { Link, useParams } from "react-router-dom";
+
+import {
+    didPlayerWin,
+    fetchHeroesMap,
+    formatDateTime,
+    formatDuration,
+    getMatchPath,
+    rankTierLabel,
+} from "../utils/dota";
+
+const DotaPlayer = () => {
+    const { steamId } = useParams();
+    const [player, setPlayer] = useState(null);
+    const [recentMatches, setRecentMatches] = useState([]);
+    const [heroesMap, setHeroesMap] = useState({});
+    const [loading, setLoading] = useState(true);
+    const [error, setError] = useState("");
+
+    useEffect(() => {
+        const controller = new AbortController();
+
+        const loadPlayerData = async () => {
+            setLoading(true);
+            setError("");
+
+            try {
+                const [profileResponse, matchesResponse, heroesData] =
+                    await Promise.all([
+                        fetch(
+                            `https://api.opendota.com/api/players/${steamId}`,
+                            {
+                                signal: controller.signal,
+                            }
+                        ),
+                        fetch(
+                            `https://api.opendota.com/api/players/${steamId}/recentMatches`,
+                            {
+                                signal: controller.signal,
+                            }
+                        ),
+                        fetchHeroesMap(controller.signal),
+                    ]);
+
+                if (!profileResponse.ok || !matchesResponse.ok) {
+                    throw new Error("Falha ao carregar dados do jogador.");
+                }
+
+                const [playerData, matchesData] = await Promise.all([
+                    profileResponse.json(),
+                    matchesResponse.json(),
+                ]);
+
+                setPlayer(playerData);
+                setRecentMatches(matchesData.slice(0, 15));
+                setHeroesMap(heroesData);
+            } catch (requestError) {
+                if (requestError.name !== "AbortError") {
+                    setError(
+                        "Não foi possível carregar os dados do jogador no momento."
+                    );
+                }
+            } finally {
+                setLoading(false);
+            }
+        };
+
+        loadPlayerData();
+
+        return () => controller.abort();
+    }, [steamId]);
+
+    return (
+        <main className="min-h-screen bg-gray-900 text-gray-100 px-4 py-10">
+            <section className="max-w-6xl mx-auto space-y-6">
+                <Link to="/dota" className="text-red-400 hover:text-red-300">
+                    ← Voltar para /dota
+                </Link>
+
+                {loading && <p>Carregando dados do player...</p>}
+                {error && <p className="text-red-400">{error}</p>}
+
+                {!loading && !error && player && (
+                    <>
+                        <header className="bg-gray-800 rounded-2xl p-6 border border-gray-700 shadow-xl">
+                            <h1 className="text-3xl font-bold">
+                                {player.profile?.personaname ||
+                                    "Jogador sem nome"}
+                            </h1>
+                            <p className="text-gray-300 mt-2">
+                                Rank: {rankTierLabel(player.rank_tier)}
+                            </p>
+                            <p className="text-gray-300">
+                                MMR estimado:{" "}
+                                {player.mmr_estimate?.estimate || "N/A"}
+                            </p>
+                            {player.profile?.avatarmedium && (
+                                <img
+                                    src={player.profile.avatarmedium}
+                                    alt={player.profile.personaname}
+                                    className="mt-4 rounded-full w-24 h-24"
+                                />
+                            )}
+                        </header>
+
+                        <section className="bg-gray-800 rounded-2xl p-6 border border-gray-700 shadow-xl">
+                            <h2 className="text-2xl font-semibold mb-4">
+                                Últimas partidas
+                            </h2>
+                            <div className="overflow-x-auto">
+                                <table className="w-full text-left text-sm">
+                                    <thead>
+                                        <tr className="text-gray-400 border-b border-gray-700">
+                                            <th className="py-2">Herói</th>
+                                            <th className="py-2">Match</th>
+                                            <th className="py-2">K / D / A</th>
+                                            <th className="py-2">Duração</th>
+                                            <th className="py-2">Início</th>
+                                            <th className="py-2">Resultado</th>
+                                        </tr>
+                                    </thead>
+                                    <tbody>
+                                        {recentMatches.map((match) => {
+                                            const won = didPlayerWin(
+                                                match.player_slot,
+                                                match.radiant_win
+                                            );
+                                            const hero =
+                                                heroesMap[match.hero_id];
+
+                                            return (
+                                                <tr
+                                                    key={match.match_id}
+                                                    className="border-b border-gray-700 hover:bg-gray-700/40"
+                                                >
+                                                    <td className="py-2">
+                                                        <div className="flex items-center gap-2">
+                                                            {hero?.icon ? (
+                                                                <img
+                                                                    src={
+                                                                        hero.icon
+                                                                    }
+                                                                    alt={
+                                                                        hero.name
+                                                                    }
+                                                                    className="w-8 h-8 rounded"
+                                                                />
+                                                            ) : (
+                                                                <div className="w-8 h-8 rounded bg-gray-700" />
+                                                            )}
+                                                            <span>
+                                                                {hero?.name ||
+                                                                    `Hero #${match.hero_id}`}
+                                                            </span>
+                                                        </div>
+                                                    </td>
+                                                    <td className="py-2">
+                                                        <Link
+                                                            to={getMatchPath(
+                                                                steamId,
+                                                                match.match_id
+                                                            )}
+                                                            className="text-red-400 hover:text-red-300"
+                                                        >
+                                                            {match.match_id}
+                                                        </Link>
+                                                    </td>
+                                                    <td className="py-2">
+                                                        {match.kills} /{" "}
+                                                        {match.deaths} /{" "}
+                                                        {match.assists}
+                                                    </td>
+                                                    <td className="py-2">
+                                                        {formatDuration(
+                                                            match.duration
+                                                        )}
+                                                    </td>
+                                                    <td className="py-2">
+                                                        {formatDateTime(
+                                                            match.start_time
+                                                        )}
+                                                    </td>
+                                                    <td
+                                                        className={`py-2 ${
+                                                            won
+                                                                ? "text-green-400"
+                                                                : "text-red-400"
+                                                        }`}
+                                                    >
+                                                        {won
+                                                            ? "Vitória"
+                                                            : "Derrota"}
+                                                    </td>
+                                                </tr>
+                                            );
+                                        })}
+                                    </tbody>
+                                </table>
+                            </div>
+                        </section>
+                    </>
+                )}
+            </section>
+        </main>
+    );
+};
+
+export default DotaPlayer;

--- a/src/pages/DotaPlayer.js
+++ b/src/pages/DotaPlayer.js
@@ -161,7 +161,7 @@ const DotaPlayer = () => {
                                                                 steamId,
                                                                 match.match_id
                                                             )}
-                                                            className="text-red-400 hover:text-red-300"
+                                                            className="text-blue-300 hover:text-blue-200"
                                                         >
                                                             {match.match_id}
                                                         </Link>
@@ -182,11 +182,10 @@ const DotaPlayer = () => {
                                                         )}
                                                     </td>
                                                     <td
-                                                        className={`py-2 ${
-                                                            won
-                                                                ? "text-green-400"
-                                                                : "text-red-400"
-                                                        }`}
+                                                        className={`py-2 ${won
+                                                            ? "text-green-400"
+                                                            : "text-red-400"
+                                                            }`}
                                                     >
                                                         {won
                                                             ? "Vitória"

--- a/src/utils/dota.js
+++ b/src/utils/dota.js
@@ -1,0 +1,130 @@
+const STEAM_ACCOUNT_OFFSET = "76561197960265728";
+const DOTA_CDN_BASE = "https://cdn.cloudflare.steamstatic.com";
+const HEROES_URL =
+    "https://cdn.jsdelivr.net/gh/odota/dotaconstants@master/build/heroes.json";
+
+const subtractLargeNumbers = (value, offset) => {
+    let carry = 0;
+    let result = "";
+
+    const a = value.split("").reverse();
+    const b = offset.split("").reverse();
+
+    for (let index = 0; index < a.length; index += 1) {
+        const digitA = Number(a[index] || 0);
+        const digitB = Number(b[index] || 0);
+
+        let subtraction = digitA - digitB - carry;
+
+        if (subtraction < 0) {
+            subtraction += 10;
+            carry = 1;
+        } else {
+            carry = 0;
+        }
+
+        result = `${subtraction}${result}`;
+    }
+
+    return result.replace(/^0+/, "") || "0";
+};
+
+export const steamIdToAccountId = (steamId) => {
+    if (!steamId) {
+        return null;
+    }
+
+    const cleanId = `${steamId}`.trim();
+
+    if (!/^\d+$/.test(cleanId)) {
+        return null;
+    }
+
+    if (cleanId.length > 10) {
+        const accountId = subtractLargeNumbers(cleanId, STEAM_ACCOUNT_OFFSET);
+        return Number(accountId);
+    }
+
+    return Number(cleanId);
+};
+
+export const buildDotaPlayerPath = (steamId) => {
+    const accountId = steamIdToAccountId(steamId);
+
+    if (!accountId && accountId !== 0) {
+        return null;
+    }
+
+    return `/dota/player/${accountId}`;
+};
+
+export const rankTierLabel = (rankTier) => {
+    if (!rankTier) {
+        return "Sem ranking calibrado";
+    }
+
+    const medalMap = {
+        1: "Herald",
+        2: "Guardian",
+        3: "Crusader",
+        4: "Archon",
+        5: "Legend",
+        6: "Ancient",
+        7: "Divine",
+        8: "Immortal",
+    };
+
+    const medal = Math.floor(rankTier / 10);
+    const stars = rankTier % 10;
+
+    return `${medalMap[medal] || "Unknown"}${stars ? ` ${stars}` : ""}`;
+};
+
+export const formatDuration = (durationInSeconds) => {
+    if (!durationInSeconds && durationInSeconds !== 0) {
+        return "N/A";
+    }
+
+    const minutes = Math.floor(durationInSeconds / 60);
+    const seconds = durationInSeconds % 60;
+
+    return `${minutes}m ${String(seconds).padStart(2, "0")}s`;
+};
+
+export const formatDateTime = (unixTime) => {
+    if (!unixTime) {
+        return "N/A";
+    }
+
+    return new Date(unixTime * 1000).toLocaleString("pt-BR");
+};
+
+export const isRadiantPlayer = (playerSlot) => playerSlot < 128;
+
+export const didPlayerWin = (playerSlot, radiantWin) =>
+    (isRadiantPlayer(playerSlot) && radiantWin) ||
+    (!isRadiantPlayer(playerSlot) && !radiantWin);
+
+export const getMatchPath = (accountId, matchId) =>
+    `/dota/player/${accountId}/match/${matchId}`;
+
+export const fetchHeroesMap = async (signal) => {
+    const response = await fetch(HEROES_URL, { signal });
+
+    if (!response.ok) {
+        throw new Error("Falha ao carregar catálogo de heróis");
+    }
+
+    const data = await response.json();
+
+    return Object.values(data).reduce((accumulator, hero) => {
+        accumulator[hero.id] = {
+            id: hero.id,
+            name: hero.localized_name,
+            icon: hero.icon ? `${DOTA_CDN_BASE}${hero.icon}` : "",
+            image: hero.img ? `${DOTA_CDN_BASE}${hero.img}` : "",
+        };
+
+        return accumulator;
+    }, {});
+};

--- a/src/utils/dota.js
+++ b/src/utils/dota.js
@@ -60,6 +60,10 @@ const subtractLargeNumbers = (value, offset) => {
     return result.replace(/^0+/, "") || "0";
 };
 
+const extractHeroName = (str) => {
+    return str.replace('npc_dota_hero_', '');
+}
+
 export const steamIdToAccountId = (steamId) => {
     if (!steamId) {
         return null;
@@ -186,7 +190,7 @@ export const fetchHeroesMap = async (signal) => {
             strGain: hero.str_gain,
             agiGain: hero.agi_gain,
             intGain: hero.int_gain,
-            lore: loreData[hero.name] || "Lore não disponível no momento.",
+            lore: loreData[extractHeroName(hero.name)] || "Lore não disponível no momento.",
         };
 
         return accumulator;


### PR DESCRIPTION
### Motivation
- Introduce a Dota 2 exploration area to the site so users can search players by Steam ID/account_id and view player profiles, recent matches, and full match details using OpenDota and hero metadata.
- Support SteamID to account_id conversion for routing and provide reusable utilities for formatting and hero lookups.

### Description
- Added `src/pages/DotaHome.js` which provides a search UI for Steam IDs, a quick link to the configured Steam profile, and navigation to player pages.
- Added `src/pages/DotaPlayer.js` which fetches player profile and recent matches from OpenDota and renders a paginated table with links to match detail pages.
- Added `src/pages/DotaMatch.js` which loads match details and hero metadata, and renders Radiant/Dire team tables with stats and result indicators.
- Added `src/utils/dota.js` implementing `steamIdToAccountId`, path builders (`buildDotaPlayerPath`, `getMatchPath`), formatters (`formatDuration`, `formatDateTime`, `rankTierLabel`), helpers (`isRadiantPlayer`, `didPlayerWin`) and `fetchHeroesMap` to load hero icons and images.
- Registered new routes in `src/App.js` for `/dota`, `/dota/player/:steamId` and `/dota/player/:steamId/match/:matchId` and added sample `dota` info to `src/assets/data.js`.

### Testing
- No automated tests were added or modified for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699df50c68a48326901679486e589209)